### PR TITLE
Add peekJoker to prevent RNG state changes on spoilers

### DIFF
--- a/___tests___/spoiler_peek.spec.ts
+++ b/___tests___/spoiler_peek.spec.ts
@@ -1,0 +1,48 @@
+import { expect, test } from "vitest";
+import { analyzeSeed } from "../src/modules/ImmolateWrapper";
+import { options } from "../src/modules/const";
+
+function getAnte2BossArcanaSpoilerJokers(cardsPerAnte: number): string[] {
+  const results = analyzeSeed(
+    {
+      seed: "TYTWAA1P",
+      deck: "Plasma Deck",
+      stake: "White Stake",
+      gameVersion: "10106",
+      antes: 2,
+      cardsPerAnte,
+    },
+    {
+      buys: {},
+      sells: {},
+      showCardSpoilers: true,
+      unlocks: options,
+      events: [],
+      lockedCards: {},
+    }
+  ) as any;
+
+  const packs = results?.antes?.[2]?.blinds?.bossBlind?.packs ?? [];
+  const arcanaPacks = packs.filter((p: any) => p?.name === "Arcana");
+  const jokerNames = arcanaPacks.flatMap((p: any) =>
+    (p?.cards ?? [])
+      .filter((c: any) => c?.type === "Joker")
+      .map((c: any) => c?.name)
+  );
+
+  return jokerNames;
+}
+
+test("TYTWAA1P: Judgement spoiler does not change when Cards per Ante changes", () => {
+  const at50 = getAnte2BossArcanaSpoilerJokers(50);
+  const at100 = getAnte2BossArcanaSpoilerJokers(100);
+  const at150 = getAnte2BossArcanaSpoilerJokers(150);
+
+  expect(at50.length).toBeGreaterThan(0);
+  expect(at50).toEqual(at100);
+  expect(at50).toEqual(at150);
+
+  expect(at50).toContain("Ice Cream");
+  expect(at50).not.toContain("Sixth Sense");
+});
+

--- a/src/modules/ImmolateWrapper/CardEngines/Cards.ts
+++ b/src/modules/ImmolateWrapper/CardEngines/Cards.ts
@@ -331,7 +331,9 @@ export class Pack {
                 continue;
             }
             if (typeof data === 'string' && itemsWithSpoilers.includes(data) && spoilers) {
-                let joker = instance.nextJoker(instance.commonSources[data], ante, true);
+                // Peek/spoiler should not advance underlying RNG state
+                // @ts-ignore - Game implements peekJoker, but CardEngine interface may not.
+                let joker = (instance.peekJoker ? instance.peekJoker(instance.commonSources[data], ante, true) : instance.nextJoker(instance.commonSources[data], ante, true));
                 let commonCardInterface = {
                     name: joker.joker,
                     type: cardType,

--- a/src/modules/ImmolateWrapper/index.ts
+++ b/src/modules/ImmolateWrapper/index.ts
@@ -543,7 +543,7 @@ export function analyzeSeed(settings: AnalyzeSettings, analyzeOptions: AnalyzeOp
             let shopItem = engine.nextShopItem(ante);
             let spoilerSource = engine.hasSpoilersMap[shopItem.item.name];
             if (engine.hasSpoilers && spoilerSource) {
-                const joker: JokerData = engine.nextJoker(spoilerSource, ante, true);
+                const joker: JokerData = engine.peekJoker(spoilerSource, ante, true);
                 result.queue.push(
                     engineWrapper.makeGameCard(joker)
                 )
@@ -560,7 +560,7 @@ export function analyzeSeed(settings: AnalyzeSettings, analyzeOptions: AnalyzeOp
             if (analyzeOptions && analyzeOptions?.showCardSpoilers) {
                 if (itemsWithSpoilers.includes(result.queue[i].name)) {
                     // @ts-ignore
-                    result.queue[i] = Pack.PackCardToCard(engine.nextJoker(spoilerSources[itemsWithSpoilers.indexOf(result.queue[i].name)], ante, false), 'Joker')
+                    result.queue[i] = Pack.PackCardToCard(engine.peekJoker(spoilerSources[itemsWithSpoilers.indexOf(result.queue[i].name)], ante, false), 'Joker')
                 }
             }
             if (analyzeOptions && analyzeOptions.buys[key]) {
@@ -672,7 +672,7 @@ export function analyzeSeed(settings: AnalyzeSettings, analyzeOptions: AnalyzeOp
                 )
                 let spoilerSource = engine.hasSpoilersMap[card.name];
                 if (engine.hasSpoilers && spoilerSource) {
-                    card = engine.nextJoker(spoilerSource, ante, true)
+                    card = engine.peekJoker(spoilerSource, ante, true)
                 }
                 let generatedCard = engineWrapper.makeGameCard(card);
                 if (analyzeOptions && analyzeOptions.buys[key]) {

--- a/src/modules/balatrots/BalatroAnalyzer.ts
+++ b/src/modules/balatrots/BalatroAnalyzer.ts
@@ -386,7 +386,7 @@ export class BalatroAnalyzer {
                 )
                 let spoilerSource = this.hasSpoilersMap[card.name];
                 if( this.hasSpoilers && spoilerSource) {
-                    let joker = game.nextJoker(spoilerSource, this.result.ante, true);
+                    let joker = game.peekJoker(spoilerSource, this.result.ante, true);
                     // @ts-ignore
                     BalatroAnalyzer.getSticker(joker);
                     card = joker
@@ -416,7 +416,7 @@ export class BalatroAnalyzer {
         let sticker: Edition | null = null;
         let spoilerSource = this.hasSpoilersMap[shopItem.item.name];
         if (this.hasSpoilers && spoilerSource) {
-            const joker: JokerData = game.nextJoker(spoilerSource, ante, true);
+            const joker: JokerData = game.peekJoker(spoilerSource, ante, true);
             run.addJoker(joker.joker.getName());
             sticker = BalatroAnalyzer.getSticker(joker);
             this.result.addItemToShopQueue(joker);
@@ -483,7 +483,7 @@ export class BalatroAnalyzer {
                 if (item === "The Soul") {
                     run.hasTheSoul = true;
                 }
-                let joker = game.nextJoker(spoilerSource, this.result.ante, true);
+                let joker = game.peekJoker(spoilerSource, this.result.ante, true);
                 run.addJoker(joker.joker.getName());
                 const sticker = BalatroAnalyzer.getSticker(joker);
                 options.add(new Option(joker.joker, new ItemImpl(sticker)));

--- a/src/modules/balatrots/Cache.ts
+++ b/src/modules/balatrots/Cache.ts
@@ -1,10 +1,59 @@
 export class Cache {
     private nodes: Map<string, number>;
     private generatedFirstPack: boolean;
+    private tracking: boolean;
+    private changes: Map<string, number | undefined>;
 
     constructor() {
         this.nodes = new Map();
         this.generatedFirstPack = false;
+        this.tracking = false;
+        this.changes = new Map();
+    }
+
+    /**
+     * Runs `fn` and rolls back any cache mutations performed during the call.
+     * Used for "peek" operations that should not consume RNG/cache state.
+     *
+     * Cost is proportional to the number of keys mutated during the call (not total cache size).
+     */
+    public withRollback<T>(fn: () => T): T {
+        const prevGeneratedFirstPack = this.generatedFirstPack;
+        const prevTracking = this.tracking;
+        const prevChanges = this.changes;
+
+        this.tracking = true;
+        this.changes = new Map();
+
+        try {
+            return fn();
+        } finally {
+            for (const [key, prevValue] of this.changes.entries()) {
+                if (prevValue === undefined) {
+                    this.nodes.delete(key);
+                } else {
+                    this.nodes.set(key, prevValue);
+                }
+            }
+
+            this.generatedFirstPack = prevGeneratedFirstPack;
+
+            // Restore nesting state
+            this.tracking = prevTracking;
+            this.changes = prevChanges;
+        }
+    }
+
+    public exportState(): { nodes: Map<string, number>; generatedFirstPack: boolean } {
+        return {
+            nodes: new Map(this.nodes),
+            generatedFirstPack: this.generatedFirstPack,
+        };
+    }
+
+    public importState(state: { nodes: Map<string, number>; generatedFirstPack: boolean }): void {
+        this.nodes = new Map(state.nodes);
+        this.generatedFirstPack = state.generatedFirstPack;
     }
 
     public isGeneratedFirstPack(): boolean {
@@ -20,6 +69,9 @@ export class Cache {
     }
 
     public setNode(key: string, value: number) {
+        if (this.tracking && !this.changes.has(key)) {
+            this.changes.set(key, this.nodes.get(key));
+        }
         this.nodes.set(key, value);
     }
 }


### PR DESCRIPTION
Introduces a `peekJoker(...)` method to the Game class and updates all spoiler/peek logic to use it instead of nextJoker, ensuring that revealing spoilers does not advance the underlying RNG or cache state.

Adds a rollback mechanism to the Cache class for efficient state restoration during peek operations.

Includes a new test to verify that spoilers remain consistent regardless of cards per ante.
Closes #4 